### PR TITLE
Allow empty string flag color on transactions

### DIFF
--- a/docs/TransactionFlagColor.md
+++ b/docs/TransactionFlagColor.md
@@ -16,6 +16,8 @@ The transaction flag
 
 * `PURPLE` (value: `'purple'`)
 
+* `EMPTY` (value: `''`)
+
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 
 

--- a/open_api_spec.yaml
+++ b/open_api_spec.yaml
@@ -3385,6 +3385,7 @@ components:
         - green
         - blue
         - purple
+        - ""
         - null
       nullable: true
     TransactionFlagName:

--- a/ynab/models/transaction_flag_color.py
+++ b/ynab/models/transaction_flag_color.py
@@ -32,6 +32,7 @@ class TransactionFlagColor(str, Enum):
     GREEN = 'green'
     BLUE = 'blue'
     PURPLE = 'purple'
+    EMPTY = ''
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:


### PR DESCRIPTION
The server sometimes returns an empty string for a transaction `flag_color`.  This change allows for that in the model validation.

Fixes #7 