### PR TITLE
Use PyPI Trusted Publishing (OIDC) in `publish.yml` instead of an API token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,7 @@ jobs:
     permissions:
       id-token: write  # required for PyPI Trusted Publishing (OIDC)
       contents: write  # create the GitHub Release
-      issues: write  # comment on PRs included in the release
-      pull-requests: write
+      pull-requests: write  # comment on PRs included in the release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,11 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # required for PyPI Trusted Publishing (OIDC)
+      contents: write  # create the GitHub Release
+      issues: write  # comment on PRs included in the release
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -45,9 +50,7 @@ jobs:
           git commit -m 'Bumping version for ${{ steps.bump_version.outputs.new_version }}'
           git push
       - name: Publish to PyPI
-        env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.POETRY_PYPI_TOKEN_PYPI }}
-        run: poetry publish      
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
       - name: Create a Release
         id: create-release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0


### PR DESCRIPTION
I've configured GitHub Actions as a [Trusted Publisher](https://docs.pypi.org/trusted-publishers/) for this project on PyPI, so the publish workflow no longer needs a long-lived API token. This swaps the token-based `poetry publish` step for the official `pypa/gh-action-pypi-publish` action, which authenticates via OIDC. Poetry itself doesn't speak OIDC, but it still handles the build; the action just publishes whatever `poetry build` put in `dist/`, which is its default package directory.

The job now declares an explicit `permissions` block to grant `id-token: write` (required for OIDC). Since declaring permissions drops everything else to `none`, the block also restores `contents: write` (creating the GitHub Release) and `issues`/`pull-requests: write` (the step that comments on PRs included in the release). The commit-and-push step is unaffected because it uses the `GH_API_TOKEN` PAT. The new action is pinned by commit SHA to match the rest of the workflow.

The Trusted Publisher on PyPI is configured against this repo and the `publish.yml` filename, with no environment restriction.

A similar change was made for the Ruby SDK [here](https://github.com/ynab/ynab-sdk-ruby/pull/94).

### Follow-ups after the first successful publish

- Delete the `POETRY_PYPI_TOKEN_PYPI` repo secret
- Revoke the old API token on PyPI