### PR TITLE
Fix PATCH /transactions success response code: 209 -> 200

### DIFF
--- a/docs/TransactionsApi.md
+++ b/docs/TransactionsApi.md
@@ -947,7 +947,7 @@ Name | Type | Description  | Notes
 
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
-**209** | The transactions were successfully updated |  -  |
+**200** | The transactions were successfully updated |  -  |
 **400** | The request could not be understood due to malformed syntax or validation error(s). |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/open_api_spec.yaml
+++ b/open_api_spec.yaml
@@ -1189,7 +1189,7 @@ paths:
               $ref: "#/components/schemas/PatchTransactionsWrapper"
         required: true
       responses:
-        "209":
+        "200":
           description: The transactions were successfully updated
           content:
             application/json:

--- a/tests/test_response_deserialize.py
+++ b/tests/test_response_deserialize.py
@@ -1,6 +1,8 @@
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+import ynab
+from ynab.api.transactions_api import TransactionsApi
 from ynab.api_client import ApiClient
 from ynab.rest import RESTResponse
 
@@ -35,3 +37,40 @@ def test_deserialize_user_response():
 
     assert result.status_code == 200
     assert str(result.data.data.user.id) == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+def test_update_transactions_with_http_info_deserializes_real_200_response():
+    """Regression test: TransactionsApi.update_transactions must map status
+    200, not 209, in its own generated _response_types_map.
+
+    The spec previously declared updateTransactions' success response as
+    HTTP 209, but the real API returns 200. Since 200 didn't match the
+    hardcoded map inside update_transactions/_with_http_info/
+    _without_preload_content, every real, successful call silently
+    deserialized to data=None -- callers had no way to tell the request
+    had in fact succeeded. This calls the real generated method (not a
+    hand-supplied response_types_map) so it actually exercises the fixed
+    value embedded in transactions_api.py.
+    """
+    client = ApiClient()
+    rest_resp = make_rest_response(200, {
+        "data": {
+            "transaction_ids": ["aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"],
+            "transactions": [],
+            "duplicate_import_ids": [],
+            "server_knowledge": 1,
+        }
+    })
+
+    with patch.object(ApiClient, "call_api", return_value=rest_resp):
+        api = TransactionsApi(client)
+        result = api.update_transactions_with_http_info(
+            plan_id="last-used",
+            data=ynab.PatchTransactionsWrapper(transactions=[]),
+        )
+
+    assert result.status_code == 200
+    assert result.data is not None
+    assert result.data.data.transaction_ids == [
+        "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    ]

--- a/ynab/api/transactions_api.py
+++ b/ynab/api/transactions_api.py
@@ -3344,7 +3344,7 @@ class TransactionsApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            '209': "SaveTransactionsResponse",
+            '200': "SaveTransactionsResponse",
             '400': "ErrorResponse",
         }
         response_data = self.api_client.call_api(
@@ -3416,7 +3416,7 @@ class TransactionsApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            '209': "SaveTransactionsResponse",
+            '200': "SaveTransactionsResponse",
             '400': "ErrorResponse",
         }
         response_data = self.api_client.call_api(
@@ -3488,7 +3488,7 @@ class TransactionsApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            '209': "SaveTransactionsResponse",
+            '200': "SaveTransactionsResponse",
             '400': "ErrorResponse",
         }
         response_data = self.api_client.call_api(


### PR DESCRIPTION
Fixes #33.

## What's wrong

`updateTransactions` (`PATCH /transactions`) declares its success response as HTTP `209` in `open_api_spec.yaml`, but the real API returns `200`. Since the generated `_response_types_map` in `TransactionsApi.update_transactions()` / `_with_http_info()` / `_without_preload_content()` only has an entry for `'209'`, every real successful call silently deserializes to `data=None` instead of raising or returning the parsed `SaveTransactionsResponse` -- see #33 for the full repro and impact (a caller checking `response.data` after a non-exception call gets an `AttributeError`, even though the mutation already applied server-side).

Every other `TransactionsApi` endpoint has a correctly-mapped status code; this is isolated to the one batch-update endpoint.

## What this changes

- `open_api_spec.yaml`: `"209"` -> `"200"` for `updateTransactions`'s success response (the only `"209"` in the whole spec).
- `ynab/api/transactions_api.py`: the three matching `_response_types_map` entries (`update_transactions`, `update_transactions_with_http_info`, `update_transactions_without_preload_content`).
- `docs/TransactionsApi.md`: the corresponding status-code table row.
- `tests/test_response_deserialize.py`: a new regression test that calls the *real* generated `update_transactions_with_http_info()` (not a hand-supplied `response_types_map`, so it actually exercises the embedded map) against a mocked `200` response and asserts `result.data is not None`. I verified this test fails against the pre-fix code (`result.data` is `None`) and passes after the fix.

I don't have `openapi-generator` available locally, so this is a precise hand-patch of the single changed value rather than a full regenerate -- following the same pattern as #3. `docs/`, spec, and generated code all agree, and the full existing suite (161 tests) plus the new one (162 total) pass.

One thing worth flagging for maintainers: `scripts/generate.sh` re-downloads `open_api_spec.yaml` fresh from `https://api.ynab.com/papi/open_api_spec.yaml` on every regen, so this fix could get silently reverted by the next `Generate from server spec` PR unless the same `209`->`200` correction also lands in YNAB's canonical spec. I don't have visibility into that system, so noted in #33 in case it needs a separate internal escalation.

## Testing

```
$ poetry run pytest
============================= 162 passed in 0.46s ==============================
```