### PR TITLE
Configure Dependabot version updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
+#
+# Order is important; the last matching pattern takes the most precedence.
+
+# Paths that Dependabot PRs can touch
+/pyproject.toml @ynab/full-stack
+/poetry.lock @ynab/full-stack
+/requirements.txt @ynab/full-stack
+/test-requirements.txt @ynab/full-stack
+/.github/ @ynab/full-stack

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,4 @@
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
-#
-# Order is important; the last matching pattern takes the most precedence.
 
 # Paths that Dependabot PRs can touch
 /pyproject.toml @ynab/full-stack

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
 # Paths that Dependabot PRs can touch
-/pyproject.toml @ynab/full-stack
-/poetry.lock @ynab/full-stack
-/requirements.txt @ynab/full-stack
-/test-requirements.txt @ynab/full-stack
-/.github/ @ynab/full-stack
+/pyproject.toml @bradymholt
+/poetry.lock @bradymholt
+/requirements.txt @bradymholt
+/test-requirements.txt @bradymholt
+/.github/ @bradymholt

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Documentation on this file: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+#
+# Reviewers are assigned via .github/CODEOWNERS (the `reviewers` option was
+# retired by GitHub in favor of code owners).
+
+version: 2
+updates:
+  # Covers pyproject.toml/poetry.lock, requirements.txt, and test-requirements.txt
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Enables Dependabot **version** updates in this repo.

### dependabot.yml

- Weekly schedule, `open-pull-requests-limit: 3`, and `cooldown.default-days: 7`. The cooldown means we don't pick up a release the day it's published, which is our main supply-chain guard.
- `github-actions` is included so workflow action versions stay current too.

### CODEOWNERS

Dependabot's `reviewers` option [was retired in August 2025](https://github.blog/changelog/2025-08-08-dependabot-reviewers-configuration-option-is-replaced-by-code-owners/) in favor of code owners, so CODEOWNERS is now the only way to route these PRs to a team. `assignees` still exists but only accepts individual users, not teams.
